### PR TITLE
Update build path in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,16 +33,16 @@ Add an initializer to configure
 
 ```ruby
 Humid.configure do |config|
-  # Path to your build file located in `app/assets/build/`. You should use a
+  # Path to your build file located in `app/assets/builds/`. You should use a
   # separate build apart from your `application.js`.
   #
   # Required
-  config.application_path = Rails.root.join('app', 'assets', 'build', 'server_rendering.js')
+  config.application_path = Rails.root.join('app', 'assets', 'builds', 'server_rendering.js')
 
   # Path to your source map file
   #
   # Optional
-  config.source_map_path = Rails.root.join('app', 'assets', 'build', 'server_rendering.js.map')
+  config.source_map_path = Rails.root.join('app', 'assets', 'builds', 'server_rendering.js.map')
 
   # Raise errors if JS rendering failed. If false, the error will be
   # logged out to Rails log and Humid.render will return an empty string


### PR DESCRIPTION
This change updates Readme to suit the rails default naming convention for the build folder from `build` to `builds`