### PR TITLE
Address deprecation of configurable

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,10 +9,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ['3.3', '3.2', '3.1']
-        rails: ['7.0', '7.1']
+        ruby: ["3.4", "3.3", "3.2"]
+        rails: ["8.0", "8.1"]
 
-    runs-on: 'ubuntu-latest'
+    runs-on: "ubuntu-latest"
     env:
       ARUBA_TIMEOUT: 240
       BUNDLE_GEMFILE: gemfiles/rails${{ matrix.rails }}.gemfile
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 18
-          cache: 'yarn'
+          cache: "yarn"
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}

--- a/Gemfile
+++ b/Gemfile
@@ -5,4 +5,5 @@ gemspec
 gem "rake"
 gem "rspec"
 gem "byebug"
-gem 'rails', '~> 7.0'
+gem 'rails', '~> 8.0'
+gem 'mutex_m'

--- a/README.md
+++ b/README.md
@@ -54,8 +54,8 @@ Humid.configure do |config|
   # `console.log` and friends (`warn`, `error`) are delegated to
   # the respective logger levels on the ruby side.
   #
-  # Defaults to `Logger.new(STDOUT)`
-  config.logger = Rails.logger
+  # Defaults to `nil`
+  config.logger = Rails.env.development? ? Rails.logger : nil
 
   # Options passed to mini_racer.
   #

--- a/gemfiles/rails8.0.gemfile
+++ b/gemfiles/rails8.0.gemfile
@@ -5,4 +5,4 @@ gemspec name: "humid", path: "../"
 gem "rake"
 gem "rspec"
 gem "byebug"
-gem 'rails', '~> 7.0.0'
+gem 'rails', '~> 8.0.0'

--- a/gemfiles/rails8.1.gemfile
+++ b/gemfiles/rails8.1.gemfile
@@ -5,4 +5,4 @@ gemspec name: "humid", path: "../"
 gem "rake"
 gem "rspec"
 gem "byebug"
-gem 'rails', '~> 7.1.0'
+gem 'rails', '~> 8.1.0'

--- a/humid.gemspec
+++ b/humid.gemspec
@@ -13,5 +13,5 @@ Gem::Specification.new do |s|
   s.files = Dir["MIT-LICENSE", "README.md", "lib/**/*"]
 
   s.add_dependency "mini_racer", ">= 0.4"
-  s.add_dependency "activesupport", ">= 7.0"
+  s.add_dependency "activesupport", "~> 8.0"
 end

--- a/lib/humid.rb
+++ b/lib/humid.rb
@@ -6,106 +6,104 @@ require "humid/log_subscriber"
 require "humid/controller_runtime"
 require "humid/version"
 
-module Humid
-  extend self
-  include ActiveSupport::Configurable
+class Humid
+  @@context = nil
 
   class RenderError < StandardError
   end
 
   class FileNotFound < StandardError
   end
+  
+  class_attribute :config
 
-  @@context = nil
+  self.config = ActiveSupport::OrderedOptions.new.merge({
+    raise_render_errors: true,
+    context_options: {},
+  })
 
-  config_accessor :application_path
-  config_accessor :source_map_path
-
-  config_accessor :raise_render_errors do
-    true
-  end
-
-  config_accessor :logger do
-    Logger.new($stdout)
-  end
-
-  config_accessor :context_options do
-    {}
-  end
-
-  def remove_functions
-    <<~JS
-      delete this.setTimeout;
-      delete this.setInterval;
-      delete this.clearTimeout;
-      delete this.clearInterval;
-      delete this.setImmediate;
-      delete this.clearImmediate;
-    JS
-  end
-
-  def logger
-    config.logger
-  end
-
-  def renderer
-    <<~JS
-      var __renderer;
-      function setHumidRenderer(fn) {
-        __renderer = fn;
-      }
-    JS
-  end
-
-  def context
-    @@context
-  end
-
-  def dispose
-    if @@context
-      @@context.dispose
-      @@context = nil
-    end
-  end
-
-  def create_context
-    ctx = MiniRacer::Context.new(**config.context_options)
-    ctx.attach("console.log", proc { |err| logger.debug(err.to_s) })
-    ctx.attach("console.info", proc { |err| logger.info(err.to_s) })
-    ctx.attach("console.error", proc { |err| logger.error(err.to_s) })
-    ctx.attach("console.warn", proc { |err| logger.warn(err.to_s) })
-
-    js = ""
-    js << remove_functions
-    js << renderer
-    ctx.eval(js)
-
-    source_path = config.application_path
-    map_path = config.source_map_path
-
-    if map_path
-      ctx.attach("readSourceMap", proc { File.read(map_path) })
+  class << self
+    def configure
+      yield config
     end
 
-    filename = File.basename(source_path.to_s)
-    @@current_filename = filename
-    ctx.eval(File.read(source_path), filename: filename)
+    def remove_functions
+      <<~JS
+        delete this.setTimeout;
+        delete this.setInterval;
+        delete this.clearTimeout;
+        delete this.clearInterval;
+        delete this.setImmediate;
+        delete this.clearImmediate;
+      JS
+    end
 
-    @@context = ctx
-  end
+    def logger
+      config.logger
+    end
 
-  def render(*args)
-    ActiveSupport::Notifications.instrument("render.humid") do
-      context.call("__renderer", *args)
-    rescue MiniRacer::RuntimeError => e
-      message = ([e.message] + e.backtrace.filter { |x| x.starts_with? "JavaScript" }).join("\n")
-      render_error = Humid::RenderError.new(message)
+    def renderer
+      <<~JS
+        var __renderer;
+        function setHumidRenderer(fn) {
+          __renderer = fn;
+        }
+      JS
+    end
 
-      if config.raise_render_errors
-        raise render_error
-      else
-        config.logger.error(render_error.inspect)
-        ""
+    def context
+      @@context
+    end
+
+    def dispose
+      if @@context
+        @@context.dispose
+        @@context = nil
+      end
+    end
+
+    def create_context
+      ctx = MiniRacer::Context.new(**config.context_options)
+
+      if logger
+        ctx.attach("console.log", proc { |err| logger.debug(err.to_s) })
+        ctx.attach("console.info", proc { |err| logger.info(err.to_s) })
+        ctx.attach("console.error", proc { |err| logger.error(err.to_s) })
+        ctx.attach("console.warn", proc { |err| logger.warn(err.to_s) })
+      end
+
+      js = ""
+      js << remove_functions
+      js << renderer
+      ctx.eval(js)
+
+      source_path = config.application_path
+      map_path = config.source_map_path
+
+      if map_path
+        ctx.attach("readSourceMap", proc { File.read(map_path) })
+      end
+
+      filename = File.basename(source_path.to_s)
+      @@current_filename = filename
+      ctx.eval(File.read(source_path), filename: filename)
+
+      @@context = ctx
+    end
+
+    def render(*args)
+      ActiveSupport::Notifications.instrument("render.humid") do
+        context.call("__renderer", *args)
+      rescue MiniRacer::RuntimeError => e
+        message = ([e.message] + e.backtrace.filter { |x| x.starts_with? "JavaScript" }).join("\n")
+        render_error = Humid::RenderError.new(message)
+
+        if config.raise_render_errors
+          raise render_error
+        else
+          config.logger.error(render_error.inspect)
+          ""
+        end
       end
     end
   end

--- a/lib/humid/controller_runtime.rb
+++ b/lib/humid/controller_runtime.rb
@@ -1,4 +1,4 @@
-module Humid
+class Humid
   module ControllerRuntime
     extend ActiveSupport::Concern
 

--- a/lib/humid/log_subscriber.rb
+++ b/lib/humid/log_subscriber.rb
@@ -1,4 +1,4 @@
-module Humid
+class Humid
   class LogSubscriber < ActiveSupport::LogSubscriber
     thread_cattr_accessor :humid_runtime
 

--- a/lib/humid/version.rb
+++ b/lib/humid/version.rb
@@ -1,3 +1,3 @@
-module Humid
+class Humid
   VERSION = "0.0.6".freeze
 end

--- a/spec/render_spec.rb
+++ b/spec/render_spec.rb
@@ -47,10 +47,23 @@ RSpec.describe "Humid" do
 
     it "proxies to Rails logger" do
       allow(Humid.config).to receive("application_path") { js_path "simple.js" }
+      Humid.config.logger = Logger.new($stdout)
+
       Humid.create_context
       expect(Humid.logger).to receive(:info).with("hello")
 
       Humid.context.eval("console.info('hello')")
+      Humid.config.logger = nil
+    end
+    
+    it "does not set the logger if none is configured" do
+      allow(Humid.config).to receive("application_path") { js_path "simple.js" }
+
+      Humid.create_context
+
+      expect {
+        Humid.context.eval("console.log('hello')")
+      }.not_to raise_error
     end
   end
 


### PR DESCRIPTION
For context see https://github.com/rails/rails/pull/53970. We're also moving away from a top level module to class and use a version constraint for the supported rails versions only.